### PR TITLE
SDK: adds `type: module` to package.json

### DIFF
--- a/packages/frame-sdk/package.json
+++ b/packages/frame-sdk/package.json
@@ -2,6 +2,8 @@
   "name": "@farcaster/frame-sdk",
   "version": "0.0.4",
   "main": "dist/index.js",
+
+  "type": "module",
   "scripts": {
     "clean": "rm -rf dist",
     "prebuild": "npm run clean",

--- a/packages/frame-sdk/scripts/build.js
+++ b/packages/frame-sdk/scripts/build.js
@@ -1,4 +1,4 @@
-const esbuild = require('esbuild')
+import esbuild from 'esbuild'
 
 esbuild.buildSync({
   entryPoints: ['src/index.ts'],


### PR DESCRIPTION
I was getting `SyntaxError: Cannot use import statement outside a module` when trying to use the SDK in my project. 

I previously made a PR to build CommonJS but the most simple solution is to add `type: module` to the SDK's package.json. 