### PR TITLE
support Ethereum Provider events, preserve errors over the wire

### DIFF
--- a/.changeset/stupid-steaks-fail.md
+++ b/.changeset/stupid-steaks-fail.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/frame-core": patch
+"@farcaster/frame-host": patch
+"@farcaster/frame-sdk": patch
+---
+
+Support Ethereum Provider events, preserve errors over the wire

--- a/packages/frame-core/package.json
+++ b/packages/frame-core/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "ox": "^0.1.6",
+    "ox": "^0.4.0",
     "zod": "^3.23.8"
   },
   "publishConfig": {

--- a/packages/frame-core/src/types.ts
+++ b/packages/frame-core/src/types.ts
@@ -1,4 +1,4 @@
-import type { Provider, RpcSchema } from "ox";
+import type { Address, Provider, RpcRequest, RpcResponse, RpcSchema } from "ox";
 import { z } from "zod";
 
 export type SetPrimaryButton = (options: {
@@ -57,10 +57,9 @@ export type FrameHost = {
   openUrl: (url: string) => void;
   setPrimaryButton: SetPrimaryButton;
   ethProviderRequest: EthProviderRequest;
+  ethProviderRequestV2: RpcTransport;
   addFrame: AddFrame;
 };
-
-// Webhook event format (= JSON Farcaster Signature)
 
 export const eventSchema = z.object({
   header: z.string(),
@@ -141,3 +140,37 @@ export const sendNotificationResponseSchema = z.object({
 export type SendNotificationResponse = z.infer<
   typeof sendNotificationResponseSchema
 >;
+
+export type RpcTransport = (
+  request: RpcRequest.RpcRequest
+) => Promise<RpcResponse.RpcResponse>;
+
+export type ProviderRpcError = {
+  code: number;
+  details?: string;
+  message?: string;
+}
+
+export type EthProviderWireEvent = {
+  event: "accountsChanged",
+  params: [readonly Address.Address[]]
+} | {
+  event: "chainChanged",
+  params: [string]
+} | {
+  event: "connect",
+  params: [Provider.ConnectInfo]
+} | {
+  event: "disconnect",
+  params: [ProviderRpcError]
+} | {
+  event: "message",
+  params: [Provider.Message]
+};
+
+export type EmitEthProvider = <
+  event extends EthProviderWireEvent['event']
+>(
+  event: event,
+  params: Extract<EthProviderWireEvent, { event: event }>['params']
+) => void;

--- a/packages/frame-host/package.json
+++ b/packages/frame-host/package.json
@@ -27,6 +27,7 @@
     "react-native-webview": ">=13.0.0"
   },
   "dependencies": {
-    "@farcaster/frame-core": "^0.0.5"
+    "@farcaster/frame-core": "^0.0.5",
+    "ox": "^0.4.0"
   }
 }

--- a/packages/frame-host/src/helpers/provider.ts
+++ b/packages/frame-host/src/helpers/provider.ts
@@ -1,0 +1,102 @@
+import { Provider, RpcRequest, RpcResponse } from "ox";
+import { WebViewEndpoint } from "../endpoint";
+import { EventMap } from "ox/_types/core/Provider";
+
+export function forwardProviderEvents(
+  provider: Provider.Provider, 
+  endpoint: WebViewEndpoint
+) {
+  let accountsChanged: EventMap['accountsChanged'] = (accounts) => {
+    endpoint.emitEthProvider('accountsChanged', [accounts]);
+  };
+  let chainChanged: EventMap['chainChanged'] = (chainId) => {
+    endpoint.emitEthProvider('chainChanged', [chainId]);
+  };
+  let connect: EventMap['connect'] = (connectInfo) => {
+    endpoint.emitEthProvider('connect', [connectInfo]);
+  };
+  let disconnect: EventMap['disconnect'] = (providerRpcError) => {
+    endpoint.emitEthProvider('disconnect', [providerRpcError]);
+  };
+  let message: EventMap['message'] = (message) => {
+    endpoint.emitEthProvider('message', [message]);
+  };
+
+  provider.on("accountsChanged", accountsChanged);
+  provider.on("chainChanged", chainChanged);
+  provider.on("connect", connect);
+  provider.on("disconnect", disconnect);
+  provider.on("message", message);
+
+  return () => {
+    provider.removeListener("accountsChanged", accountsChanged);
+    provider.removeListener("chainChanged", chainChanged);
+    provider.removeListener("connect", connect);
+    provider.removeListener("disconnect", disconnect);
+    provider.removeListener("message", message);
+  }
+}
+
+// export type FrameTransport<
+//   raw extends boolean = false,
+//   schema extends RpcSchema.Generic = RpcSchema.Default,
+// > = RP RpcTransport<raw, {}, schema>
+
+/**
+  * Wraps a provider's request function with a result format that can transfer
+  * errors across scripting boundaries.
+  */
+export const wrapProviderRequest = (provider: Provider.Provider) => 
+ async (request: RpcRequest.RpcRequest) => {
+  try {
+    const result = await provider.request(request);
+
+    return RpcResponse.from(
+      { result }, 
+      { request }
+    );
+  } catch (e) {
+    if (e instanceof Provider.ProviderRpcError) {
+      return RpcResponse.from(
+        {
+          error: {
+            message: e.message,
+            code: e.code,
+            details: e.details,
+          }
+        }, 
+        { request }
+      );
+    }
+
+    if (e !== null 
+      && typeof e === 'object' 
+      && 'message' in e 
+      && typeof e.message === 'string' 
+      && 'code' in e
+      && typeof e.code === 'number' 
+    ) {
+      return RpcResponse.from(
+        {
+          error: {
+            message: e.message,
+            code: e.code,
+            details: 'details' in e && typeof e.details === 'string' ? e.details : undefined
+          }
+        }, 
+        { request }
+      );
+    }
+
+    const errorMessage = e instanceof Error ? e.message : "Unknown";
+    return RpcResponse.from(
+      {
+        error: {
+          message: errorMessage,
+          code: 1000,
+        }
+      }, 
+      { request }
+    );
+  }
+}

--- a/packages/frame-sdk/package.json
+++ b/packages/frame-sdk/package.json
@@ -23,9 +23,6 @@
     "@farcaster/frame-core": "^0.0.5",
     "comlink": "^4.4.2",
     "eventemitter3": "^5.0.1",
-    "ox": "^0.2.2"
-  },
-  "peerDependencies": {
-    "ox": "^0.2.2"
+    "ox": "^0.4.0"
   }
 }

--- a/packages/frame-sdk/src/provider.ts
+++ b/packages/frame-sdk/src/provider.ts
@@ -1,26 +1,75 @@
-import { Provider, RpcRequest } from "ox";
+import { Provider, RpcRequest, RpcResponse } from "ox";
 import { frameHost } from "./frameHost";
+import { EthProviderWireEvent } from "@farcaster/frame-core";
 
 const emitter = Provider.createEmitter();
 const store = RpcRequest.createStore();
 
-export const provider = Provider.from({
+type GenericProviderRpcError = {
+  code: number;
+  details?: string;
+}
+
+export function toProviderRpcError({ code, details }: GenericProviderRpcError): Provider.ProviderRpcError {
+  switch (code) {
+    case 4001:
+      return new Provider.UserRejectedRequestError();
+    case 4100:
+      return new Provider.UnauthorizedError();
+    case 4200:
+      return new Provider.UnsupportedMethodError();
+    case 4900:
+      return new Provider.DisconnectedError();
+    case 4901:
+      return new Provider.ChainDisconnectedError();
+    default:
+      return new Provider.ProviderRpcError(code, details ?? 'Unknown provider RPC error');
+  }
+}
+
+export const provider: Provider.Provider = Provider.from({
   ...emitter,
   async request(args) {
-    return await frameHost.ethProviderRequest(
-      // @ts-expect-error - from ox examples but our FetchFn needs better typing
-      store.prepare(args),
-    );
-  },
+    // @ts-expect-error
+    const request = store.prepare(args);
+
+    try {
+      const response = await frameHost.ethProviderRequestV2(
+        request
+      ).then((res) => RpcResponse.parse(res, { request, raw: true }));
+
+
+      if (response.error) {
+        throw toProviderRpcError(response.error)
+      }
+
+      return response.result;
+    } catch (e) {
+      // ethProviderRequestV2 not supported, fall back to v1
+      if (e instanceof Error && e.message.match(/cannot read property 'apply'/i)) {
+        return await frameHost.ethProviderRequest(request);
+      }
+
+      if (
+        e instanceof Provider.ProviderRpcError ||
+        e instanceof RpcResponse.BaseError
+      ) {
+        throw e;
+      }
+
+
+      throw new RpcResponse.InternalError({ message: e instanceof Error ? e.message : undefined })
+    }
+  }
 });
 
-export type ProviderType = typeof provider;
-
 // Required to pass SSR
-if (typeof document !== 'undefined')
-  document.addEventListener("FarcasterFrameEvent", (event) => {
+if (typeof document !== 'undefined') {
+  document.addEventListener("FarcasterFrameEthProviderEvent", (event) => {
     if (event instanceof MessageEvent) {
-      // TODO narrow to EventMap types and emit
-      // emitter.emit(event.type as (keyof Provider.EventMap), event.data);
+      const ethProviderEvent = event.data as EthProviderWireEvent;
+      // @ts-expect-error 
+      emitter.emit(ethProviderEvent.event, ...ethProviderEvent.params);
     }
   });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,23 +3243,10 @@ outdent@^0.5.0:
   resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.5.0.tgz#9e10982fdc41492bb473ad13840d22f9655be2ff"
   integrity sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==
 
-ox@^0.1.6:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/ox/-/ox-0.1.8.tgz#0ba58eb6f2471c607959c40fa39b2fa5c4f4f7e5"
-  integrity sha512-GJl6uKXxhPq/XgyvAnIokGuGU/pt9CU8reRJjzi4a02HOpLc2CEXXD4bRCITFFAzdRqHj3DQ6GDS7PlCytPM/A==
-  dependencies:
-    "@adraffy/ens-normalize" "^1.10.1"
-    "@noble/curves" "^1.6.0"
-    "@noble/hashes" "^1.5.0"
-    "@scure/bip32" "^1.5.0"
-    "@scure/bip39" "^1.4.0"
-    abitype "^1.0.6"
-    eventemitter3 "5.0.1"
-
-ox@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ox/-/ox-0.2.2.tgz#b177912d2fd9853e52c2db8570ac29c09330cec1"
-  integrity sha512-QWCyFfVk5hFOhg13SGqRKih5B7EBucrf+Z1dfmN9jJQ8MZdrRx9mbD78JQL5ogSzDT7fcHgyMCaXd/3AWn6xHQ==
+ox@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.4.0.tgz#6c73b27a9f45912888917304d7a81c894856a980"
+  integrity sha512-F+Q8R/7SZ8AvBcejIV6QUcACLjRuFtSShCkwTuCFWLAN5DoS8dSwiFsDBltvQplEXXNGmAEZCV4HDe7orEDSxA==
   dependencies:
     "@adraffy/ens-normalize" "^1.10.1"
     "@noble/curves" "^1.6.0"


### PR DESCRIPTION
**Preserve provider errors over the wire**
`ethProviderRequestV2` implements a JSON-RPC transport. `wrapProviderRequest` will take a normal provider that will throw and return a JSON-RPC compliant transport function.

**Support Ethereum Provider events**
Add a dedicated event for emitting 

**Note for frame-host implementers**
You can now pass an Ethereum Provider to `useWebViewRpcAdapter` and it will:
- wrap the `request` function and attach it to `ethProviderRequestV2`
- forward provider events over the wire

```
  const { onMessage, emit } = useWebViewRpcAdapter(
    webViewRef,
    sdk,
    walletProvider,
  );
```