### PR TITLE
add ready options with disableNativeGesture

### DIFF
--- a/.changeset/grumpy-papayas-kneel.md
+++ b/.changeset/grumpy-papayas-kneel.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/frame-core": patch
+"@farcaster/frame-sdk": patch
+---
+
+add ready options with disableNativeGestures

--- a/examples/vanilla/src/main.ts
+++ b/examples/vanilla/src/main.ts
@@ -15,7 +15,7 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 `
 
 const frameHost: FrameHost = {
-  ready: () => {
+  ready: (_options) => {
     document.querySelector<HTMLDivElement>('#splash')!.hidden = true;
   }
 } as FrameHost;

--- a/packages/frame-core/src/types.ts
+++ b/packages/frame-core/src/types.ts
@@ -65,7 +65,13 @@ export type AddFrame = () => Promise<AddFrameResult>;
 export type FrameHost = {
   context: FrameContext;
   close: () => void;
-  ready: () => void;
+  ready: (options: Partial<{ 
+    /**
+      * Disable native gestures. Use this option if your frame uses gestures
+      * that conflict with native gestures. 
+      */
+    disableNativeGestures: boolean; 
+  }>) => void;
   openUrl: (url: string) => void;
   setPrimaryButton: SetPrimaryButton;
   ethProviderRequest: EthProviderRequest;

--- a/packages/frame-sdk/src/types.ts
+++ b/packages/frame-sdk/src/types.ts
@@ -1,6 +1,6 @@
 import type { EventEmitter } from "eventemitter3";
 import type { Provider } from "ox";
-import type { FrameContext, AddFrame } from "@farcaster/frame-core";
+import type { FrameContext, AddFrame, FrameHost } from "@farcaster/frame-core";
 
 declare global {
   interface Window {
@@ -31,7 +31,7 @@ export type SetPrimaryButton = (options: {
 export type FrameSDK = {
   context: Promise<FrameContext>;
   actions: {
-    ready: () => Promise<void>;
+    ready: FrameHost['ready'];
     openUrl: (url: string) => Promise<void>;
     close: () => Promise<void>;
     setPrimaryButton: SetPrimaryButton;


### PR DESCRIPTION
Use `disableNativeGesture` if your frame uses gestures that conflict with native gestures like swipe to dismiss.