### PR TITLE
fix: Improve Button Focus Styling Update style.css

### DIFF
--- a/examples/vanilla/src/style.css
+++ b/examples/vanilla/src/style.css
@@ -79,7 +79,7 @@ button:hover {
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 4px auto rgba(0, 123, 255, 0.6); /* Or any other desired color */
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
The button `:focus` and `:focus-visible` styles currently rely on the WebKit-specific value `-webkit-focus-ring-color` for the `outline` property. While this works in WebKit-based browsers like Safari and some versions of Chrome, it does not provide full compatibility with other engines like Gecko or Blink.  

To enhance cross-browser compatibility, the `outline` property has been updated to use a more universally supported color value.  

#### Changes:  
- Replaced:  
  ```css
  button:focus,
  button:focus-visible {
    outline: 4px auto -webkit-focus-ring-color;
  }
  ```  

- With:  
  ```css
  button:focus,
  button:focus-visible {
    outline: 4px auto rgba(0, 123, 255, 0.6); /* A neutral, accessible color */
  }
  ```  

This ensures consistent focus styling across all modern browsers, improving accessibility and user experience.  