### PR TITLE
fix: enforced engine restriction and improve build config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Farcaster Frames Monorepo
+
+## Prerequisites
+
+- Node.js 18+
+- Yarn 1.22+
+
+## Development
+Install dependencies
+```bash
+yarn install
+```
+Build packages
+```bash
+yarn build
+```
+Start development server
+```bash
+yarn dev
+```
+

--- a/examples/vanilla/tsconfig.json
+++ b/examples/vanilla/tsconfig.json
@@ -17,8 +17,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["frame"]
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "frames",
   "private": true,
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
+    "build": "turbo run build --filter=@farcaster/frame-core --filter=@farcaster/frame-sdk --filter=@farcaster/frame-host",
+    "dev": "turbo run build --filter=@farcaster/frame-core --filter=@farcaster/frame-sdk && turbo run dev",
     "typecheck": "turbo typecheck",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "publish-packages": "turbo run build typecheck && changeset version && changeset publish"


### PR DESCRIPTION
## Description
- Introduced engine restriction for stricter `Node.js` version enforcement.
- Introduced filters in build scripts for better package management.
- Added development instructions for easier on-boarding.

## Testing introduced `fix`
- Clone this PR branch
- Install dependencies with: 
  ```bash 
  yarn install 
  ```
- And then from the root directory, run: 
  ```bash 
  yarn build 
  ```