### PR TITLE
Add frame-react package

### DIFF
--- a/packages/frame-react/package.json
+++ b/packages/frame-react/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@farcaster/frame-react",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prebuild": "npm run clean",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "devDependencies": {
+    "@farcaster/tsconfig": "*",
+    "@types/react": "^18.3.12",
+    "react": "^18.3.1",
+    "typescript": "^5.6.3"
+  },
+  "peerDependencies": {
+    "@farcaster/frame-sdk": "^0.0.16",
+    "react": ">=18.0.0"
+  }
+}

--- a/packages/frame-react/src/context.tsx
+++ b/packages/frame-react/src/context.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import frameSDK from '@farcaster/frame-sdk'
+import type { FrameContext, ReadyOptions } from '@farcaster/frame-core'
+
+interface FrameProviderProps {
+  children: React.ReactNode
+  config?: ReadyOptions
+}
+
+const Context = createContext<FrameContext | undefined>(undefined)
+
+export function FrameProvider({ children, config }: FrameProviderProps) {
+  const [isFrameSDKLoaded, setIsFrameSDKLoaded] = useState(false)
+  const [context, setContext] = useState<FrameContext>()
+
+  useEffect(() => {
+    const load = async () => {
+      setContext(await frameSDK.context)
+      frameSDK.actions.ready(config)
+    }
+
+    if (frameSDK && !isFrameSDKLoaded) {
+      setIsFrameSDKLoaded(true)
+      load()
+    }
+  }, [isFrameSDKLoaded])
+
+  return <Context.Provider value={context}>{children}</Context.Provider>
+}
+
+export function useFrame() {
+  return useContext(Context)
+}

--- a/packages/frame-react/src/index.ts
+++ b/packages/frame-react/src/index.ts
@@ -1,0 +1,1 @@
+export * from './context'

--- a/packages/frame-react/tsconfig.json
+++ b/packages/frame-react/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@farcaster/tsconfig/browser.json",
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "preserve"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,14 +1167,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz#168ab1c7e1c318b922637fad8f339d48b01e1244"
   integrity sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==
 
-"@farcaster/frame-core@^0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@farcaster/frame-core/-/frame-core-0.0.13.tgz#cd4739488a7492f9b4f7b302f0220e8955b3d4aa"
-  integrity sha512-PXs2SJnt8GAKw4JspfBSWLKfvx1mGiWGZ8aB46ehMQMUtsN7k5gzSIdgWLpN47OeVEsi1X86fW6i8YkoL6L/nQ==
-  dependencies:
-    ox "^0.4.0"
-    zod "^3.23.8"
-
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"


### PR DESCRIPTION
This package makes loading the frame-sdk and fetching data from its context easier. It can probably be implemented directly into the frame-sdk package, but I followed the repo's pattern of making a new one.

Basic implementation in a Next.js app (assumes the dev has already added the custom connector to `wagmiConfig`):

```tsx
// Providers.tsx
'use client'

import { FrameProvider } from '@farcaster/frame-react'
import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
import { WagmiProvider } from 'wagmi'

import { wagmiConfig } from '@/lib/web3'

const queryClient = new QueryClient()

export function ClientProviders({ children }: { children: React.ReactNode }) {
  return (
    <WagmiProvider config={wagmiConfig}>
      <QueryClientProvider client={queryClient}>
        <FrameProvider>{children}</FrameProvider>
      </QueryClientProvider>
    </WagmiProvider>
  )
}
```

Then from any client component:

```tsx
// page.tsx
'use client'

import { useFrame } from '@farcaster/frame-react'

export default function Page() {
  const frameContext = useFrame()

  return <div>Hello {frameContext?.user.username}</div>
}
```