### PR TITLE
Add imageUrl and buttonTitle to domain manifest frame config

### DIFF
--- a/.changeset/dull-ladybugs-tap.md
+++ b/.changeset/dull-ladybugs-tap.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/frame-core": patch
+---
+
+Add imageUrl and buttonTitle to domain manifest frame config

--- a/packages/frame-core/src/schemas/embeds.ts
+++ b/packages/frame-core/src/schemas/embeds.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { hexColorSchema, frameNameSchema, secureUrlSchema } from "./shared";
+import {
+  hexColorSchema,
+  frameNameSchema,
+  secureUrlSchema,
+  buttonTitleSchema,
+} from "./shared";
 
 export const actionLaunchFrameSchema = z.object({
   type: z.literal("launch_frame"),
@@ -12,8 +17,6 @@ export const actionLaunchFrameSchema = z.object({
 export const actionSchema = z.discriminatedUnion("type", [
   actionLaunchFrameSchema,
 ]);
-
-export const buttonTitleSchema = z.string().max(32);
 
 export const buttonSchema = z.object({
   title: buttonTitleSchema,

--- a/packages/frame-core/src/schemas/manifest.ts
+++ b/packages/frame-core/src/schemas/manifest.ts
@@ -4,6 +4,7 @@ import {
   frameNameSchema,
   hexColorSchema,
   encodedJsonFarcasterSignatureSchema,
+  buttonTitleSchema,
 } from "./shared";
 
 export const domainFrameConfigSchema = z.object({
@@ -13,6 +14,8 @@ export const domainFrameConfigSchema = z.object({
   name: frameNameSchema,
   iconUrl: secureUrlSchema,
   homeUrl: secureUrlSchema,
+  imageUrl: secureUrlSchema.optional(),
+  buttonTitle: buttonTitleSchema.optional(),
   splashImageUrl: secureUrlSchema.optional(),
   splashBackgroundColor: hexColorSchema.optional(),
   webhookUrl: secureUrlSchema.optional(),

--- a/packages/frame-core/src/schemas/shared.ts
+++ b/packages/frame-core/src/schemas/shared.ts
@@ -7,6 +7,7 @@ export const secureUrlSchema = z
   .max(512);
 
 export const frameNameSchema = z.string().max(32);
+export const buttonTitleSchema = z.string().max(32);
 
 export const hexColorSchema = z
   .string()


### PR DESCRIPTION
This allows Farcaster clients to render the frame launch UI (image + button) outside of a cast embed, e.g. when surfacing the frame in notifications
