### PR TITLE
use @wagmi/core instead of wagmi for connector.ts

### DIFF
--- a/packages/frame-wagmi-connector/package.json
+++ b/packages/frame-wagmi-connector/package.json
@@ -21,7 +21,7 @@
     "tsup": "^8.3.5",
     "typescript": "^5.6.3",
     "viem": "^2.21.55",
-    "wagmi": "^2.14.1"
+    "@wagmi/core": "^2.14.1"
   },
   "publishConfig": {
     "access": "public"
@@ -29,6 +29,6 @@
   "peerDependencies": {
     "@farcaster/frame-sdk": "^0.0.18",
     "viem": "^2.21.55",
-    "wagmi": "^2.14.1"
+    "@wagmi/core": "^2.14.1"
   }
 }

--- a/packages/frame-wagmi-connector/src/connector.ts
+++ b/packages/frame-wagmi-connector/src/connector.ts
@@ -1,6 +1,6 @@
 import FrameSDK from '@farcaster/frame-sdk'
 import { SwitchChainError, fromHex, getAddress, numberToHex } from 'viem'
-import { ChainNotConfiguredError, Connector, createConnector } from 'wagmi'
+import { ChainNotConfiguredError, Connector, createConnector } from '@wagmi/core'
 
 farcasterFrame.type = 'farcasterFrame' as const
 


### PR DESCRIPTION
Test hello test, I can't seem to run the yarn build to check that these still compile due to maybe the order of which libraries get build (I'm just js newb) but these changes should use the underlying @wagmi/core instead of the wagmi react library for the connector code, so that non-react projects don't need to include the full react wagmi library just for the connector package