### PR TITLE
docs(changeset): add embed to cast_embed location context

### DIFF
--- a/.changeset/orange-seas-yell.md
+++ b/.changeset/orange-seas-yell.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/frame-core": patch
+---
+
+add embed to cast_embed location context

--- a/packages/frame-core/src/types.ts
+++ b/packages/frame-core/src/types.ts
@@ -33,6 +33,7 @@ export type AccountLocation = {
 
 export type FrameLocationContextCastEmbed = {
   type: "cast_embed";
+  embed: string;
   cast: {
     fid: number;
     hash: string;


### PR DESCRIPTION
Frames don't currently know which embed URL they launched from, since the frame's action URL can be different than the embed. Add embed URL to the location context.