### PR TITLE
Fix Typos in `manifest.ts` and `comlink.ts`

### DIFF
--- a/packages/frame-core/src/schemas/manifest.ts
+++ b/packages/frame-core/src/schemas/manifest.ts
@@ -9,7 +9,7 @@ import {
 
 export const domainFrameConfigSchema = z.object({
   // 0.0.0 and 0.0.1 are not technically part of the spec but kept for
-  // backwards compatibilty. next should always resolve to the most recent
+  // backwards compatibility. next should always resolve to the most recent
   // schema version.
   version: z.union([
     z.literal('0.0.0'),

--- a/packages/frame-host/src/comlink/comlink.ts
+++ b/packages/frame-host/src/comlink/comlink.ts
@@ -361,7 +361,7 @@ export function expose(
         const [wireValue, transferables] = toWireValue(returnValue)
         ep.postMessage({ ...wireValue, id }, transferables)
         if (type === MessageType.RELEASE) {
-          // detach and deactive after sending release response above.
+          // detach and deactivate after sending release response above.
           ep.removeEventListener('message', callback as any)
           closeEndPoint(ep)
           if (finalizer in obj && typeof obj[finalizer] === 'function') {


### PR DESCRIPTION
# Fix Typos in `manifest.ts` and `comlink.ts`

## Description

This pull request fixes minor typos in the following files:
- **`manifest.ts`**: Corrected "compatibilty" to "compatibility."
- **`comlink.ts`**: Corrected "deactive" to "deactivate."

These changes improve code readability and maintain consistent documentation.

---

## Changes Made

- Corrected a typo in `packages/frame-core/src/schemas/manifest.ts`:
  - **Before**: `compatibilty`
  - **After**: `compatibility`
- Corrected a typo in `packages/frame-host/src/comlink/comlink.ts`:
  - **Before**: `deactive`
  - **After**: `deactivate`

---

## Checklist

- [x] Code changes follow the project's style guide.
- [x] No functional changes were introduced.
- [x] Changes were reviewed and tested locally.

---

## Related Issues

No related issues were reported.

---

## Testing

No testing required as the changes are non-functional and involve textual corrections.

---

Let me know if further adjustments are required!
