### PR TITLE
[frame-host] add missing react peer-dependencyTd/node ver

### DIFF
--- a/.changeset/purple-hornets-poke.md
+++ b/.changeset/purple-hornets-poke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/frame-host": patch
+---
+
+add missing react peerDependency

--- a/packages/frame-host/package.json
+++ b/packages/frame-host/package.json
@@ -8,14 +8,21 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit"
   },
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "devDependencies": {
     "@farcaster/tsconfig": "workspace:*",
     "@types/react": "^18.3.18",
+    "react": "^18.3.1",
     "typescript": "^5.7.2"
   },
   "dependencies": {
     "@farcaster/frame-core": "workspace:*",
     "ox": "^0.4.4"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0"
   }
 }

--- a/packages/frame-host/package.json
+++ b/packages/frame-host/package.json
@@ -8,10 +8,7 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "devDependencies": {
     "@farcaster/tsconfig": "workspace:*",
     "@types/react": "^18.3.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.18
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
       typescript:
         specifier: ^5.7.2
         version: 5.7.2


### PR DESCRIPTION
frame-host was importing from react but didn't have it listed as a dependency.

for 1.0.0 we should remove react a dependency and introduce a frame-host-react package or just provide a simple example 