### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/packages/frame-sdk/src/types.ts
+++ b/packages/frame-sdk/src/types.ts
@@ -20,7 +20,7 @@ declare global {
 }
 
 /** Combines members of an intersection into a readable type. */
-// https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=v01xkqU3KO0Mg
+// https://x.com/mattpocockuk/status/1622730173446557697?s=20&t=v01xkqU3KO0Mg
 type Compute<type> = { [key in keyof type]: type[key] } & unknown
 
 export type EventMap = {


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.